### PR TITLE
Implement device-based Firestore rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,29 +72,18 @@ cd V2Fitness
 1. Create a new Firebase project at [Firebase Console](https://console.firebase.google.com/)
 2. Enable Firestore Database
 3. Download `google-services.json` and place it in `app/` directory
-4. Configure Firestore security rules:
+4. Configure Firestore security rules using the `firestore.rules` file located
+   at the repository root. The rules define an `isApproved(deviceId)` helper
+   that checks `/approved_devices/{deviceId}` for a document whose
+   `deviceStatus` field equals `"approved"`. All reads and writes in the main
+   collections (`qr_codes`, `attendance`, `daily_usage`) require this helper,
+   ensuring only approved devices can access data.
 
-```javascript
-rules_version = '2';
-service cloud.firestore {
-  match /databases/{database}/documents {
-    // QR Codes collection
-    match /qr_codes/{qrId} {
-      allow read, write: if request.auth != null;
-    }
-    
-    // Attendance collection
-    match /attendance/{attendanceId} {
-      allow read, write: if request.auth != null;
-    }
-    
-    // Daily usage collection
-    match /daily_usage/{usageId} {
-      allow read, write: if request.auth != null;
-    }
-  }
-}
-```
+   Deploy the rules with:
+
+   ```bash
+   firebase deploy --only firestore:rules
+   ```
 
 ### 3. Build and Run
 ```bash

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,31 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isApproved(deviceId) {
+      return deviceId != null &&
+             exists(/databases/$(database)/documents/approved_devices/$(deviceId)) &&
+             get(/databases/$(database)/documents/approved_devices/$(deviceId)).data.deviceStatus == "approved";
+    }
+
+    match /qr_codes/{qrId} {
+      allow create, update, delete: if isApproved(request.resource.data.deviceId);
+      allow read: if isApproved(resource.data.deviceId);
+    }
+
+    match /attendance/{attendanceId} {
+      allow create, update, delete: if isApproved(request.resource.data.deviceId);
+      allow read: if isApproved(resource.data.deviceId);
+    }
+
+    match /daily_usage/{usageId} {
+      allow create, update, delete: if isApproved(request.resource.data.deviceId);
+      allow read: if isApproved(resource.data.deviceId);
+    }
+
+    match /approved_devices/{deviceId} {
+      allow create, update, delete: if isApproved(deviceId) ||
+                                    !exists(/databases/$(database)/documents/approved_devices/$(deviceId));
+      allow read: if isApproved(deviceId);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `firestore.rules` with `isApproved` helper
- document rule deployment in Firebase setup instructions

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871182ab6808332be25ac6b8d048201